### PR TITLE
Added support for overriding the default comment model

### DIFF
--- a/resources/config/commentable.php
+++ b/resources/config/commentable.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom model
+    |--------------------------------------------------------------------------
+    |
+    | This option allows for the extension of the commentable model, by pointing it to a model
+    |
+    */
+	'model' => \DraperStudio\Commentable\Models\Comment::class,
+
+];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -24,6 +24,12 @@ class ServiceProvider extends \DraperStudio\ServiceProvider\ServiceProvider
     public function boot()
     {
         $this->publishMigrations();
+
+        $this->publishes([
+            __DIR__ . '/../../../resources/config/commentable.php' => config_path('commentable.php')
+        ]);
+
+        $this->mergeConfigFrom(__DIR__ . '/../resources/config/commentable.php', 'commentable');
     }
 
     /**

--- a/src/Traits/Commentable.php
+++ b/src/Traits/Commentable.php
@@ -11,7 +11,6 @@
 
 namespace DraperStudio\Commentable\Traits;
 
-use DraperStudio\Commentable\Models\Comment;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -21,12 +20,21 @@ use Illuminate\Database\Eloquent\Model;
  */
 trait Commentable
 {
+
+    /**
+     * @return string
+     */
+    public function commentable_model()
+    {
+        return config('commentable.model');
+    }
+
     /**
      * @return mixed
      */
     public function comments()
     {
-        return $this->morphMany(Comment::class, 'commentable');
+        return $this->morphMany($this->commentable_model(), 'commentable');
     }
 
     /**
@@ -38,7 +46,9 @@ trait Commentable
      */
     public function comment($data, Model $creator, Model $parent = null)
     {
-        $comment = (new Comment())->createComment($this, $data, $creator);
+        $commentableModel = $this->commentable_model();
+
+        $comment = (new $commentableModel)->createComment($this, $data, $creator);
 
         if (!empty($parent)) {
             $comment->appendTo($parent)->save();
@@ -56,7 +66,9 @@ trait Commentable
      */
     public function updateComment($id, $data, Model $parent = null)
     {
-        $comment = (new Comment())->updateComment($id, $data);
+        $commentableModel = $this->commentable_model();
+
+        $comment = (new $commentableModel)->updateComment($id, $data);
 
         if (!empty($parent)) {
             $comment->appendTo($parent)->save();
@@ -72,7 +84,9 @@ trait Commentable
      */
     public function deleteComment($id)
     {
-        return (new Comment())->deleteComment($id);
+        $commentableModel = $this->commentable_model();
+
+        return (new $commentableModel)->deleteComment($id);
     }
 
     /**


### PR DESCRIPTION
Added support for overriding the default comment model

## Changes proposed in this pull request:
- Allowing the user to define the Comment model in config

